### PR TITLE
Fix third check of touchscreen detection.

### DIFF
--- a/touchscreen-detection/index.html
+++ b/touchscreen-detection/index.html
@@ -31,7 +31,7 @@ pre { width: 100%; overflow: auto; background: #eee; }
     if (window.matchMedia &amp;&amp; window.matchMedia("(any-pointer:coarse)").matches) {
       // check for any-pointer:coarse which mostly means touchscreen
       result = true;
-    } else if (window.TouchEvent || ('ontouchstart' in window)) {
+    } else if (window.TouchEvent && ('ontouchstart' in window)) {
       // last resort - check for exposed touch events API / event handler
       result = true;
     }
@@ -61,7 +61,7 @@ function detectTouchscreen() {
     if (window.matchMedia && window.matchMedia("(any-pointer:coarse)").matches) {
       // check for any-pointer:coarse which mostly means touchscreen
       result = true;
-    } else if (window.TouchEvent || ('ontouchstart' in window)) {
+    } else if (window.TouchEvent && ('ontouchstart' in window)) {
       // last resort - check for exposed touch events API / event handler
       result = true;
     }


### PR DESCRIPTION
The third check whether a touchscreen is enabled isn't working properly.
`window.TouchEvent || ('ontouchstart' in window)` returns true as long as there is a TouchEvent object available. Unfortunately this is also the case in my Chrome browser on my Desktop computer. To fix the check I replaced the OR operator with an AND operator. The second condition is only executed if the `TouchEvent` object is available.